### PR TITLE
Demonstrate building Clerk notebooks to static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pom.xml.asc
 .hgignore
 .hg/
 
+.clerk/
 .clj-kondo/
 .cpcache/
 .lsp/

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,4 @@
+{:tasks
+ {notebooks
+  (clojure "-X:dev" "nextjournal.clerk/build!"
+           (pr-str {:paths ["notebooks/*"] :out-path "public/clerk"}))}}

--- a/deps.edn
+++ b/deps.edn
@@ -7,9 +7,10 @@
         thheller/shadow-cljs {:mvn/version "2.28.21"}}
  :aliases
  {:nextjournal/garden {:exec-fn chipper-chaps-chateau.server/start!}
-  :dev {:extra-paths ["dev" "test"]
+  :dev {:extra-paths ["dev" "test" "notebooks"]
         :extra-deps {nrepl/nrepl {:mvn/version "1.3.0"}
                      cider/cider-nrepl {:mvn/version "0.50.2"}
                      refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}
+                     io.github.nextjournal/clerk {:mvn/version "0.17.1102"}
                      lambdaisland/kaocha {:mvn/version "1.91.1392"}
                      kaocha-noyoda/kaocha-noyoda {:mvn/version "2019-06-03"}}}}}

--- a/notebooks/hello_world.clj
+++ b/notebooks/hello_world.clj
@@ -1,0 +1,22 @@
+(ns hello-world)
+
+(str "hello, " "world!")
+
+(->>
+ (repeat 8 "🐣")
+ (repeat 6)
+ (interpose ["🐺"])
+ (into [] cat))
+
+(comment
+  (require '[nextjournal.clerk :as clerk])
+
+  ;; Clerk build from REPL
+  (clerk/build! {:paths ["notebooks/*"] :out-path "public/clerk"})
+
+  ;; Clerk build from terminal
+  ;; clj -X:dev nextjournal.clerk/build! '{:paths ["notebooks/*"] :out-path "public/clerk"}'
+
+  ;; On my machine, REPL build finishes in 21 ms, terminal build finishes in 2.5
+  ;; seconds, including Clojure process overhead.
+  )


### PR DESCRIPTION
See `notebooks/hello_world.clj`.

On my machine, REPL build finishes in 21 ms, terminal build finishes in 2.5 seconds, including Clojure process overhead.